### PR TITLE
Set global database connection in TestMain for job handlers

### DIFF
--- a/internal/handlers/jobs_test.go
+++ b/internal/handlers/jobs_test.go
@@ -96,6 +96,9 @@ func TestMain(m *testing.M) {
 		panic(err)
 	}
 
+	// ここでグローバルDB接続を設定
+	handlers.SetDB(db)
+
 	code := m.Run()
 
 	db.Close()


### PR DESCRIPTION
This pull request includes a small change to the `internal/handlers/jobs_test.go` file. The change sets up a global database connection in the `TestMain` function.

* [`internal/handlers/jobs_test.go`](diffhunk://#diff-e9c64563b61dfb78d1e00104869edecf4481d637b8a84a0e003b531d43eea198R99-R101): Added a call to `handlers.SetDB(db)` to set up a global database connection in the `TestMain` function.