### PR TITLE
Add CreateJobHandler to API and clean up job handler comments

### DIFF
--- a/cmd/server/router/router.go
+++ b/cmd/server/router/router.go
@@ -19,6 +19,7 @@ func NewRouter(db *sql.DB) *mux.Router {
 
 	r.HandleFunc("/api/jobs", jobHandler.GetJobsHandler).Methods(http.MethodGet)
 	r.HandleFunc("/api/jobs/{id:[0-9]+}", jobHandler.GetJobByIDHandler).Methods(http.MethodGet)
+	r.HandleFunc("/api/jobs", jobHandler.CreateJobHandler).Methods(http.MethodPost)
 
 	// frontend
 	r.HandleFunc("/", htmlHomeHandler)

--- a/internal/handlers/job_handler.go
+++ b/internal/handlers/job_handler.go
@@ -46,8 +46,6 @@ func (jH *JobHandler) GetJobsHandler(w http.ResponseWriter, req *http.Request) {
 	}
 }
 
-// GET api/jobs group by job type
-
 // GET /api/jobs/{id}
 func (jH *JobHandler) GetJobByIDHandler(w http.ResponseWriter, req *http.Request) {
 	// parse {id} from url request body
@@ -89,7 +87,6 @@ func (jH *JobHandler) GetJobByIDHandler(w http.ResponseWriter, req *http.Request
 }
 
 // POST /api/jobs
-// TODO: implement test
 func (jH *JobHandler) CreateJobHandler(w http.ResponseWriter, req *http.Request) {
 	// parse request json body to job struct
 	var job *models.Job

--- a/internal/handlers/main_test.go
+++ b/internal/handlers/main_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stretchr/testify/mock"
 )
 
+// To  avoid error "not used"
 var jobHandler *handlers.JobHandler
 
 func TestMain(m *testing.M) {


### PR DESCRIPTION
This pull request introduces a new endpoint for creating jobs and includes some minor cleanup in the codebase. The most important changes include adding a new handler for the POST `/api/jobs` endpoint and removing outdated comments.

New endpoint:

* [`cmd/server/router/router.go`](diffhunk://#diff-67fc997b7b839320f8509998331a84bc8c52acf6feba99e1e07c525b18a5a7eaR22): Added a new route handler for the POST `/api/jobs` endpoint to the router.

Code cleanup:

* [`internal/handlers/job_handler.go`](diffhunk://#diff-1516daa7da15b2e7203bb7f8521e5447f0e59af668e6d4c443e0430e77a3d1e2L49-L50): Removed outdated comments above `GetJobsHandler` and `CreateJobHandler` methods. [[1]](diffhunk://#diff-1516daa7da15b2e7203bb7f8521e5447f0e59af668e6d4c443e0430e77a3d1e2L49-L50) [[2]](diffhunk://#diff-1516daa7da15b2e7203bb7f8521e5447f0e59af668e6d4c443e0430e77a3d1e2L92)

Minor improvements:

* [`internal/handlers/main_test.go`](diffhunk://#diff-3f5f64ebcf3909a12498c1e1dc58d6e80f681b33c40b8d1d8076216e779ff374R15): Added a comment to avoid the "not used" error for the `jobHandler` variable.